### PR TITLE
Update releases.properties from release 2026.7.10

### DIFF
--- a/releases.properties
+++ b/releases.properties
@@ -1,3 +1,4 @@
+1.6.45 = https://github.com/Bearsampp/module-memcached/releases/download/2026.7.10/bearsampp-memcached-1.6.45-2026.7.10.7z
 1.6.42 = https://github.com/Bearsampp/module-memcached/releases/download/2026.6.2/bearsampp-memcached-1.6.42-2026.6.2.7z
 1.6.41 = https://github.com/Bearsampp/module-memcached/releases/download/2026.3.7/bearsampp-memcached-1.6.41-2026.3.7.7z
 1.6.40.7 = https://github.com/Bearsampp/module-memcached/releases/download/2026.1.16/bearsampp-memcached-1.6.40.7-2026.1.15.7z


### PR DESCRIPTION
## 🤖 Automated Releases Properties Update

This PR updates the `releases.properties` file with new versions from release `2026.7.10`.

### Changes:
- Extracted .7z assets from the release
- Removed stale/invalid existing URLs from `releases.properties`
- Added version entries with download URLs
- Maintained semver ordering (newest first)

**Release URL:** https://github.com/Bearsampp/module-memcached/releases/tag/2026.7.10

### Next Steps:
1. ⏳ Link validation will run automatically
2. ✅ Once validation passes, this PR will auto-merge
3. ❌ If validation fails, review logs for transient network/service issues